### PR TITLE
Modified egw template to create route between OGW and UTM VPC

### DIFF
--- a/egw/1.0/egw.template
+++ b/egw/1.0/egw.template
@@ -1,712 +1,754 @@
 {
-  "AWSTemplateFormatVersion": "2010-09-09",
-  "Parameters": {
-    "VpcID": {
-      "Description": "ID of an existing VPC to launch the deployment in.",
-      "Type": "AWS::EC2::VPC::Id"
-    },
-    "LoadBalancerSubnetID": {
-      "Description": "Subnet ID for Gateway.",
-      "Type": "AWS::EC2::Subnet::Id"
-    },
-    "KeyID": {
-      "Description": "Name of an existing EC2 KeyPair to enable SSH access.",
-      "Type": "AWS::EC2::KeyPair::KeyName"
-    },
-    "ImageID": {
-      "Description": "Autodetect uses the latest AMI. Otherwise, specify an AMI ID.",
-      "Type": "String",
-      "Default": "autodetect"
-    },
-    "InstanceSize": {
-      "Description": "The default EC2 instance type is c4.large. If c4.large is not available in your region, a similar EC2 instance type will be used.",
-      "Type": "String",
-      "Default": "default"
-    },
-    "ControllerSecurityGroup": {
-      "Description": "Security group ID of the Controller node. Only SSH access to the Gateway will be allowed from this security group.",
-      "Type": "AWS::EC2::SecurityGroup::Id"
-    },
-    "UTMWorkerSecurityGroup": {
-      "Description": "Security group ID of the instances the Gateway should balance traffic to.",
-      "Type": "AWS::EC2::SecurityGroup::Id"
-    },
-    "AuthToken": {
-      "Description": "AuthToken for API access. This token would be used as a shared secret for API communication between Gateway and the UTMs.",
-      "Type": "String",
-      "MinLength": 1
-    },
-    "LoadBalancerUID": {
-      "Description": "Unique ID for the Gateway instance. Start with 1 if you don't have any preference. (Note: Gateways with Resource Management by the UTM will use the range 8k - 16k)",
-      "Type": "Number",
-      "MinValue": 1,
-      "MaxValue": 16383
-    },
-    "LoadBalancerTunnelPrefix": {
-      "Description": "The network prefix (e.g 240.0.0.0/8) to use (changes only required in case of conflict).",
-      "Type": "Number",
-      "Default": 240,
-      "MinValue": 240,
-      "MaxValue": 254
-    },
-    "InternetGateway": {
-      "Description": "The Internet Gateway ID of the VPC.",
-      "Type": "String"
-    },
-    "ClientCIDR": {
-      "Description": "CIDR containing all clients. If in doubt, use CIDR of the whole VPC.",
-      "Type": "String",
-      "AllowedPattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/([0-9]|[1-2][0-9]|3[0-2]))$",
-      "ConstraintDescription": "Must be IPv4 CIDR notation: X.X.X.X/X"
-    }
-  },
-  "Metadata": {
-    "AWS::CloudFormation::Interface": {
-      "ParameterGroups": [
-        {
-          "Label": {
-            "default": "Gateway Configuration"
-          },
-          "Parameters": [
-            "LoadBalancerUID",
-            "LoadBalancerSubnetID",
-            "ImageID",
-            "InstanceSize",
-            "AuthToken",
-            "LoadBalancerTunnelPrefix"
-          ]
-        },
-        {
-          "Label": {
-            "default": "Infrastructure Information"
-          },
-          "Parameters": [
-            "VpcID",
-            "InternetGateway",
-            "ControllerSecurityGroup",
-            "UTMWorkerSecurityGroup",
-            "ClientCIDR"
-          ]
-        },
-        {
-          "Label": {
-            "default": "Credentials to access the Gateway"
-          },
-          "Parameters": [
-            "KeyID"
-          ]
-        }
-      ],
-      "ParameterLabels": {
-        "VpcID": {
-          "default": "VPC ID (required)"
-        },
-        "LoadBalancerSubnetID": {
-          "default": "Subnet ID of the Gateway (required)"
-        },
-        "ImageID": {
-          "default": "AMI ID (required)"
-        },
-        "InstanceSize": {
-          "default": "Instance Type (required)"
-        },
-        "AuthToken": {
-          "default": "Authorization token (required)"
-        },
-        "LoadBalancerUID": {
-          "default": "Unique ID of the Gateway (required)"
-        },
-        "LoadBalancerTunnelPrefix": {
-          "default": "IP address prefix (class A network) to be used for Gateway Tunnels (required)"
-        },
-        "InternetGateway": {
-          "default": "Internet Gateway ID (required)"
-        },
-        "ClientCIDR": {
-          "default": "CIDR of the Clients/VDIs (required)"
-        },
-        "ControllerSecurityGroup": {
-          "default": "Security Group of the Controller node (required)"
-        },
-        "UTMWorkerSecurityGroup": {
-          "default": "Security Group of the Worker nodes (required)"
-        },
-        "KeyID": {
-          "default": "SSH Key (required)"
-        }
-      }
-    }
-  },
-  "Mappings": {
-    "RegionMap": {
-      "ap-northeast-1": {
-        "EGW": "ami-0189eea3a673530fe",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      },
-      "ap-northeast-2": {
-        "EGW": "ami-032565bddf1a879c1",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      },
-      "ap-south-1": {
-        "EGW": "ami-08cbce4d5146ad7d7",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      },
-      "ap-southeast-1": {
-        "EGW": "ami-008354309002142cc",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      },
-      "ap-southeast-2": {
-        "EGW": "ami-094f46f1d48a9dec1",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      },
-      "ca-central-1": {
-        "EGW": "ami-0d7d57ef88f4ea222",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      },
-      "eu-central-1": {
-        "EGW": "ami-01d2476f545349abd",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      },
-      "eu-north-1": {
-        "EGW": "ami-0fffc0fd11916f545",
-        "ARN": "aws",
-        "EGWInstanceType": "m5.large"
-      },
-      "eu-west-1": {
-        "EGW": "ami-0fca50ef5a9fb3ec2",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      },
-      "eu-west-2": {
-        "EGW": "ami-05f83b31a6d1365db",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      },
-      "eu-west-3": {
-        "EGW": "ami-05c5f6a316d2d0d20",
-        "ARN": "aws",
-        "EGWInstanceType": "m5.large"
-      },
-      "sa-east-1": {
-        "EGW": "ami-0622432257bd2d416",
-        "ARN": "aws",
-        "EGWInstanceType": "m3.medium"
-      },
-      "us-east-1": {
-        "EGW": "ami-03aff3e0eec3f4f40",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      },
-      "us-east-2": {
-        "EGW": "ami-05e8e585c8c631ca6",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      },
-      "us-gov-east-1": {
-        "EGW": "ami-06e513067a76a05e6",
-        "ARN": "aws-us-gov",
-        "EGWInstanceType": "m5.large"
-      },
-      "us-gov-west-1": {
-        "EGW": "ami-6966fc08",
-        "ARN": "aws-us-gov",
-        "EGWInstanceType": "m4.large"
-      },
-      "us-west-1": {
-        "EGW": "ami-0f3cb25a6fd92201a",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      },
-      "us-west-2": {
-        "EGW": "ami-0c1bfac5365dc0721",
-        "ARN": "aws",
-        "EGWInstanceType": "m4.large"
-      }
-    }
-  },
-  "Conditions": {
-    "UseRegionMap": {
-      "Fn::Equals": [
-        {
-          "Ref": "ImageID"
-        },
-        "autodetect"
-      ]
-    },
-    "DetectInstanceSize": {
-      "Fn::Equals": [
-        {
-          "Ref": "InstanceSize"
-        },
-        "default"
-      ]
-    }
-  },
-  "Resources": {
-    "EGWRouteTable": {
-      "Type": "AWS::EC2::RouteTable",
-      "DependsOn": "InstanceIAMRole",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VpcID"
-        }
-      }
-    },
-    "EGWRoute": {
-      "Type": "AWS::EC2::Route",
-      "Properties": {
-        "RouteTableId": {
-          "Ref": "EGWRouteTable"
-        },
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "GatewayId": {
-          "Ref": "InternetGateway"
-        }
-      }
-    },
-    "LoadBalancerRouteTableAssociation": {
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties": {
-        "SubnetId": {
-          "Ref": "LoadBalancerSubnetID"
-        },
-        "RouteTableId": {
-          "Ref": "EGWRouteTable"
-        }
-      }
-    },
-    "InstanceIAM": {
-      "Type": "AWS::IAM::InstanceProfile",
-      "DependsOn": [
-        "InstanceIAMRole"
-      ],
-      "Properties": {
-        "Path": "/",
-        "Roles": [
-          {
-            "Ref": "InstanceIAMRole"
-          }
-        ]
-      }
-    },
-    "InstanceIAMRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "ec2.amazonaws.com"
-                ]
-              },
-              "Action": [
-                "sts:AssumeRole"
-              ]
-            }
-          ]
-        },
-        "Path": "/",
-        "Policies": [
-          {
-            "PolicyName": "Allow-Describe-EC2-And-ReplaceRoute",
-            "PolicyDocument": {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "ec2:DescribeRouteTables",
-                    "ec2:DescribeSubnets",
-                    "ec2:ReplaceRoute"
-                  ],
-                  "Resource": "*"
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "IncomingTrafficLoadBalancerSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "Incoming Traffic Group",
-        "VpcId": {
-          "Ref": "VpcID"
-        },
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "0",
-            "ToPort": "65535",
-            "CidrIp": {
-              "Ref": "ClientCIDR"
-            }
-          },
-          {
-            "IpProtocol": "udp",
-            "FromPort": "0",
-            "ToPort": "65535",
-            "CidrIp": {
-              "Ref": "ClientCIDR"
-            }
-          },
-          {
-            "IpProtocol": "icmp",
-            "FromPort": "-1",
-            "ToPort": "-1",
-            "CidrIp": {
-              "Ref": "ClientCIDR"
-            }
-          }
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "LB Incoming Traffic"
-          }
-        ]
-      }
-    },
-    "RemoteAccessSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "Remote Access Group (SSH, Control Connection)",
-        "VpcId": {
-          "Ref": "VpcID"
-        },
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "22",
-            "ToPort": "22",
-            "SourceSecurityGroupId": {
-              "Ref": "ControllerSecurityGroup"
-            }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "5555",
-            "ToPort": "5555",
-            "SourceSecurityGroupId": {
-              "Ref": "ControllerSecurityGroup"
-            }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "5555",
-            "ToPort": "5555",
-            "SourceSecurityGroupId": {
-              "Ref": "UTMWorkerSecurityGroup"
-            }
-          },
-          {
-            "IpProtocol": "47",
-            "SourceSecurityGroupId": {
-              "Ref": "UTMWorkerSecurityGroup"
-            }
-          }
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "LB Access & Control"
-          }
-        ]
-      }
-    },
-    "LoadBalancer": {
-      "Type": "AWS::EC2::Instance",
-      "DependsOn": [
-        "IncomingTrafficLoadBalancerSecurityGroup",
-        "RemoteAccessSecurityGroup",
-        "InstanceIAM"
-      ],
-      "Properties": {
-        "ImageId": {
-          "Fn::If": [
-            "UseRegionMap",
-            {
-              "Fn::FindInMap": [
-                "RegionMap",
-                {
-                  "Ref": "AWS::Region"
-                },
-                "EGW"
-              ]
-            },
-            {
-              "Ref": "ImageID"
-            }
-          ]
-        },
-        "InstanceType": {
-          "Fn::If": [
-            "DetectInstanceSize",
-            {
-              "Fn::FindInMap": [
-                "RegionMap",
-                {
-                  "Ref": "AWS::Region"
-                },
-                "EGWInstanceType"
-              ]
-            },
-            {
-              "Ref": "InstanceSize"
-            }
-          ]
-        },
-        "NetworkInterfaces": [
-          {
-            "AssociatePublicIpAddress": "true",
-            "DeviceIndex": "0",
-            "GroupSet": [
-              {
-                "Ref": "IncomingTrafficLoadBalancerSecurityGroup"
-              },
-              {
-                "Ref": "RemoteAccessSecurityGroup"
-              }
-            ],
-            "SubnetId": {
-              "Ref": "LoadBalancerSubnetID"
-            }
-          }
-        ],
-        "SourceDestCheck": "false",
-        "IamInstanceProfile": {
-          "Ref": "InstanceIAM"
-        },
-        "KeyName": {
-          "Ref": "KeyID"
-        },
-        "BlockDeviceMappings": [
-          {
-            "DeviceName": "/dev/xvda",
-            "Ebs": {
-              "VolumeSize": "25"
-            }
-          }
-        ],
-        "UserData": {
-          "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash\n",
-                "date +'UserData start %c' > /tmp/user_data.log\n",
-                "/opt/aws/bin/cfn-init -s ",
-                {
-                  "Ref": "AWS::StackId"
-                },
-                " -r LoadBalancer ",
-                "    --region ",
-                {
-                  "Ref": "AWS::Region"
-                },
-                " -c InitEGW >> /tmp/user_data.log 2>&1\n",
-                "initctl start egw >> /tmp/user_data.log 2>&1\n",
-                "/opt/aws/bin/cfn-signal '",
-                {
-                  "Ref": "WaitHandle"
-                },
-                "' >> /tmp/user_data.log 2>&1\n",
-                "echo export AWS_DEFAULT_REGION=",
-                {
-                  "Ref": "AWS::Region"
-                },
-                " > /etc/profile.d/aws-egw.sh\n",
-                "echo export AWS_INSTANCE_ID=`/opt/aws/bin/ec2-metadata --instance-id | cut -d ' ' -f 2` >> /etc/profile.d/aws-egw.sh 2>> /tmp/user_data.log\n",
-                "date +'UserData end %c' >> /tmp/user_data.log\n",
-                "exit 0\n"
-              ]
-            ]
-          }
-        },
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "LoadBalancer LB"
-          }
-        ]
-      },
-      "Metadata": {
-        "AWS::CloudFormation::Init": {
-          "configSets": {
-            "InitEGW": [
-              "InitEGW"
-            ]
-          },
-          "InitEGW": {
-            "files": {
-              "/etc/egw.conf": {
-                "content": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "{\n",
-                      "  \"prefix\": ",
-                      {
-                        "Ref": "LoadBalancerTunnelPrefix"
-                      },
-                      ",\n",
-                      "  \"uid\": ",
-                      {
-                        "Ref": "LoadBalancerUID"
-                      },
-                      ",\n",
-                      "  \"rest_auth_token\": \"",
-                      {
-                        "Ref": "AuthToken"
-                      },
-                      "\"\n",
-                      "}\n"
-                    ]
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "WaitHandle": {
-      "Type": "AWS::CloudFormation::WaitConditionHandle"
-    },
-    "WaitCondition": {
-      "Type": "AWS::CloudFormation::WaitCondition",
-      "DependsOn": [
-        "LoadBalancer"
-      ],
-      "Properties": {
-        "Handle": {
-          "Ref": "WaitHandle"
-        },
-        "Count": "1",
-        "Timeout": "600"
-      }
-    },
-    "LoadBalancerAutoRecover": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "DependsOn": [
-        "LoadBalancer"
-      ],
-      "Properties": {
-        "AlarmDescription": "Recovering LoadBalancer when underlying hardware fails.",
-        "Namespace": "AWS/EC2",
-        "MetricName": "StatusCheckFailed_System",
-        "Statistic": "Minimum",
-        "Period": "60",
-        "EvaluationPeriods": "1",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "Threshold": "0",
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Fn::FindInMap": [
-                    "RegionMap",
-                    {
-                      "Ref": "AWS::Region"
-                    },
-                    "ARN"
-                  ]
-                },
-                ":automate:",
-                {
-                  "Ref": "AWS::Region"
-                },
-                ":ec2:recover"
-              ]
-            ]
-          }
-        ],
-        "Dimensions": [
-          {
-            "Name": "InstanceId",
-            "Value": {
-              "Ref": "LoadBalancer"
-            }
-          }
-        ]
-      }
-    },
-    "LoadBalancerRestart": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "DependsOn": [
-        "LoadBalancer"
-      ],
-      "Properties": {
-        "AlarmDescription": "Restarting LoadBalancer when it fails to respond.",
-        "Namespace": "AWS/EC2",
-        "MetricName": "StatusCheckFailed_Instance",
-        "Statistic": "Minimum",
-        "Period": "60",
-        "EvaluationPeriods": "1",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "Threshold": "0",
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Fn::FindInMap": [
-                    "RegionMap",
-                    {
-                      "Ref": "AWS::Region"
-                    },
-                    "ARN"
-                  ]
-                },
-                ":swf:",
-                {
-                  "Ref": "AWS::Region"
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId"
-                },
-                ":action/actions/AWS_EC2.InstanceId.Reboot/1.0"
-              ]
-            ]
-          }
-        ],
-        "Dimensions": [
-          {
-            "Name": "InstanceId",
-            "Value": {
-              "Ref": "LoadBalancer"
-            }
-          }
-        ]
-      }
-    }
-  },
-  "Outputs": {
-    "LoadBalancerIP": {
-      "Value": {
-        "Fn::GetAtt": [
-          "LoadBalancer",
-          "PrivateIp"
-        ]
-      },
-      "Description": "Private IP address of the Load Balancer"
-    }
-  }
+	"AWSTemplateFormatVersion": "2010-09-09",
+	"Parameters": {
+		"VpcID": {
+			"Description": "ID of the existing VPC to launch the deployment in.",
+			"Type": "AWS::EC2::VPC::Id"
+		},
+		"LoadBalancerSubnetID": {
+			"Description": "Subnet ID for Outbound Gateway.",
+			"Type": "AWS::EC2::Subnet::Id"
+		},
+		"KeyID": {
+			"Description": "Name of an existing EC2 KeyPair to enable SSH access.",
+			"Type": "AWS::EC2::KeyPair::KeyName"
+		},
+		"ImageID": {
+			"Description": "Autodetect uses the latest AMI. Otherwise, specify an AMI ID.",
+			"Type": "String",
+			"Default": "autodetect"
+		},
+		"InstanceSize": {
+			"Description": "The default EC2 instance type is c4.large. If c4.large is not available in your region, a similar EC2 instance type will be used.",
+			"Type": "String",
+			"Default": "default"
+		},
+		"ControllerSecurityGroup": {
+			"Description": "Security group ID of the Controller node. Only SSH access to the Gateway will be allowed from this security group.",
+			"Type": "AWS::EC2::SecurityGroup::Id"
+		},
+		"UTMWorkerSecurityGroup": {
+			"Description": "Security group ID of the instances the Gateway should balance traffic to.",
+			"Type": "AWS::EC2::SecurityGroup::Id"
+		},
+		"AuthToken": {
+			"Description": "AuthToken for API access. This token would be used as a shared secret for API communication between Gateway and the UTMs.",
+			"Type": "String",
+			"MinLength": 1
+		},
+		"LoadBalancerUID": {
+			"Description": "Unique ID for the Gateway instance. Start with 1 if you don't have any preference. (Note: Gateways with Resource Management by the UTM will use the range 8k - 16k)",
+			"Type": "Number",
+			"MinValue": 1,
+			"MaxValue": 16383
+		},
+		"LoadBalancerTunnelPrefix": {
+			"Description": "The network prefix (e.g 240.0.0.0/8) to use (changes only required in case of conflict).",
+			"Type": "Number",
+			"Default": 240,
+			"MinValue": 240,
+			"MaxValue": 254
+		},
+		"InternetGateway": {
+			"Description": "The Internet Gateway ID of the VPC.",
+			"Type": "String"
+		},
+		"UTMGateway": {
+			"Description": "The VPC Peering ID or Transit Gateway ID for the connection between the client VPC and the UTM VPC.",
+			"Type": "String"
+		},
+		"UTMCIDR": {
+			"Description": "CIDR of the VPC containing the UTM controller and workers.",
+			"Type": "String",
+			"AllowedPattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/([0-9]|[1-2][0-9]|3[0-2]))$",
+			"ConstraintDescription": "Must be IPv4 CIDR notation: X.X.X.X/X"
+		},
+		"ClientCIDR": {
+			"Description": "CIDR containing all clients. If in doubt, use CIDR of the whole VPC.",
+			"Type": "String",
+			"AllowedPattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/([0-9]|[1-2][0-9]|3[0-2]))$",
+			"ConstraintDescription": "Must be IPv4 CIDR notation: X.X.X.X/X"
+		}
+	},
+	"Metadata": {
+		"AWS::CloudFormation::Interface": {
+			"ParameterGroups": [{
+					"Label": {
+						"default": "Gateway Configuration"
+					},
+					"Parameters": [
+						"LoadBalancerUID",
+						"LoadBalancerSubnetID",
+						"ImageID",
+						"InstanceSize",
+						"AuthToken",
+						"LoadBalancerTunnelPrefix"
+					]
+				},
+				{
+					"Label": {
+						"default": "Infrastructure Information"
+					},
+					"Parameters": [
+						"VpcID",
+						"InternetGateway",
+						"UTMGateway",
+						"ControllerSecurityGroup",
+						"UTMWorkerSecurityGroup",
+						"ClientCIDR",
+						"UTMCIDR"
+					]
+				},
+				{
+					"Label": {
+						"default": "Credentials to access the Gateway"
+					},
+					"Parameters": [
+						"KeyID"
+					]
+				}
+			],
+			"ParameterLabels": {
+				"VpcID": {
+					"default": "VPC ID (required)"
+				},
+				"LoadBalancerSubnetID": {
+					"default": "Subnet ID of the Gateway (required)"
+				},
+				"ImageID": {
+					"default": "AMI ID (required)"
+				},
+				"InstanceSize": {
+					"default": "Instance Type (required)"
+				},
+				"AuthToken": {
+					"default": "Authorization token (required)"
+				},
+				"LoadBalancerUID": {
+					"default": "Unique ID of the Gateway (required)"
+				},
+				"LoadBalancerTunnelPrefix": {
+					"default": "IP address prefix (class A network) to be used for Gateway Tunnels (required)"
+				},
+				"InternetGateway": {
+					"default": "Internet Gateway ID (required)"
+				},
+				"UTMGateway": {
+					"default": "Peering / Transit Gateway ID (required)"
+				},
+				"ClientCIDR": {
+					"default": "CIDR of the Clients/VDIs (required)"
+				},
+				"UTMCIDR": {
+					"default": "CIDR of the UTM controller and worker VPC (required)"
+				},
+				"ControllerSecurityGroup": {
+					"default": "Security Group of the Controller node (required)"
+				},
+				"UTMWorkerSecurityGroup": {
+					"default": "Security Group of the Worker nodes (required)"
+				},
+				"KeyID": {
+					"default": "SSH Key (required)"
+				}
+			}
+		}
+	},
+	"Mappings": {
+		"RegionMap": {
+			"ap-northeast-1": {
+				"EGW": "ami-0189eea3a673530fe",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			},
+			"ap-northeast-2": {
+				"EGW": "ami-032565bddf1a879c1",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			},
+			"ap-south-1": {
+				"EGW": "ami-08cbce4d5146ad7d7",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			},
+			"ap-southeast-1": {
+				"EGW": "ami-008354309002142cc",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			},
+			"ap-southeast-2": {
+				"EGW": "ami-094f46f1d48a9dec1",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			},
+			"ca-central-1": {
+				"EGW": "ami-0d7d57ef88f4ea222",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			},
+			"eu-central-1": {
+				"EGW": "ami-01d2476f545349abd",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			},
+			"eu-north-1": {
+				"EGW": "ami-0fffc0fd11916f545",
+				"ARN": "aws",
+				"EGWInstanceType": "m5.large"
+			},
+			"eu-west-1": {
+				"EGW": "ami-0fca50ef5a9fb3ec2",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			},
+			"eu-west-2": {
+				"EGW": "ami-05f83b31a6d1365db",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			},
+			"eu-west-3": {
+				"EGW": "ami-05c5f6a316d2d0d20",
+				"ARN": "aws",
+				"EGWInstanceType": "m5.large"
+			},
+			"sa-east-1": {
+				"EGW": "ami-0622432257bd2d416",
+				"ARN": "aws",
+				"EGWInstanceType": "m3.medium"
+			},
+			"us-east-1": {
+				"EGW": "ami-03aff3e0eec3f4f40",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			},
+			"us-east-2": {
+				"EGW": "ami-05e8e585c8c631ca6",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			},
+			"us-gov-east-1": {
+				"EGW": "ami-06e513067a76a05e6",
+				"ARN": "aws-us-gov",
+				"EGWInstanceType": "m5.large"
+			},
+			"us-gov-west-1": {
+				"EGW": "ami-6966fc08",
+				"ARN": "aws-us-gov",
+				"EGWInstanceType": "m4.large"
+			},
+			"us-west-1": {
+				"EGW": "ami-0f3cb25a6fd92201a",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			},
+			"us-west-2": {
+				"EGW": "ami-0c1bfac5365dc0721",
+				"ARN": "aws",
+				"EGWInstanceType": "m4.large"
+			}
+		}
+	},
+	"Conditions": {
+		"UseRegionMap": {
+			"Fn::Equals": [{
+					"Ref": "ImageID"
+				},
+				"autodetect"
+			]
+		},
+		"DetectInstanceSize": {
+			"Fn::Equals": [{
+					"Ref": "InstanceSize"
+				},
+				"default"
+			]
+		},
+		"ConnectionTypePeering": {
+			"Fn::Equals": [{
+					"Fn::Select": ["0", {
+						"Fn::Split": ["-",
+							{
+								"Ref": "UTMGateway"
+							}
+						]
+					}]
+				},
+				"pcx"
+			]
+		},
+		"ConnectionTypeGateway": {
+			"Fn::Equals": [{
+					"Fn::Select": ["0", {
+						"Fn::Split": ["-",
+							{
+								"Ref": "UTMGateway"
+							}
+						]
+					}]
+				},
+				"tgw"
+			]
+		}
+	},
+	"Resources": {
+		"EGWRouteTable": {
+			"Type": "AWS::EC2::RouteTable",
+			"DependsOn": "InstanceIAMRole",
+			"Properties": {
+				"VpcId": {
+					"Ref": "VpcID"
+				}
+			}
+		},
+		"EGWRoute": {
+			"Type": "AWS::EC2::Route",
+			"Properties": {
+				"RouteTableId": {
+					"Ref": "EGWRouteTable"
+				},
+				"DestinationCidrBlock": "0.0.0.0/0",
+				"GatewayId": {
+					"Ref": "InternetGateway"
+				}
+			}
+		},
+		"UTMRoutePeer": {
+			"Type": "AWS::EC2::Route",
+			"Condition": "ConnectionTypePeering",
+			"Properties": {
+				"RouteTableId": {
+					"Ref": "EGWRouteTable"
+				},
+				"DestinationCidrBlock": {
+					"Ref": "UTMCIDR"
+				},
+				"VpcPeeringConnectionId": {
+					"Ref": "UTMGateway"
+				}
+			}
+		},
+		"UTMRouteGateway": {
+			"Type": "AWS::EC2::Route",
+			"Condition": "ConnectionTypeGateway",
+			"Properties": {
+				"RouteTableId": {
+					"Ref": "EGWRouteTable"
+				},
+				"DestinationCidrBlock": {
+					"Ref": "UTMCIDR"
+				},
+				"TransitGatewayId": {
+					"Ref": "UTMGateway"
+				}
+			}
+		},
+		"LoadBalancerRouteTableAssociation": {
+			"Type": "AWS::EC2::SubnetRouteTableAssociation",
+			"Properties": {
+				"SubnetId": {
+					"Ref": "LoadBalancerSubnetID"
+				},
+				"RouteTableId": {
+					"Ref": "EGWRouteTable"
+				}
+			}
+		},
+		"InstanceIAM": {
+			"Type": "AWS::IAM::InstanceProfile",
+			"DependsOn": [
+				"InstanceIAMRole"
+			],
+			"Properties": {
+				"Path": "/",
+				"Roles": [{
+					"Ref": "InstanceIAMRole"
+				}]
+			}
+		},
+		"InstanceIAMRole": {
+			"Type": "AWS::IAM::Role",
+			"Properties": {
+				"AssumeRolePolicyDocument": {
+					"Version": "2012-10-17",
+					"Statement": [{
+						"Effect": "Allow",
+						"Principal": {
+							"Service": [
+								"ec2.amazonaws.com"
+							]
+						},
+						"Action": [
+							"sts:AssumeRole"
+						]
+					}]
+				},
+				"Path": "/",
+				"Policies": [{
+					"PolicyName": "Allow-Describe-EC2-And-ReplaceRoute",
+					"PolicyDocument": {
+						"Version": "2012-10-17",
+						"Statement": [{
+							"Effect": "Allow",
+							"Action": [
+								"ec2:DescribeRouteTables",
+								"ec2:DescribeSubnets",
+								"ec2:ReplaceRoute"
+							],
+							"Resource": "*"
+						}]
+					}
+				}]
+			}
+		},
+		"IncomingTrafficLoadBalancerSecurityGroup": {
+			"Type": "AWS::EC2::SecurityGroup",
+			"Properties": {
+				"GroupDescription": "Incoming Traffic Group",
+				"VpcId": {
+					"Ref": "VpcID"
+				},
+				"SecurityGroupIngress": [{
+						"IpProtocol": "tcp",
+						"FromPort": "0",
+						"ToPort": "65535",
+						"CidrIp": {
+							"Ref": "ClientCIDR"
+						}
+					},
+					{
+						"IpProtocol": "udp",
+						"FromPort": "0",
+						"ToPort": "65535",
+						"CidrIp": {
+							"Ref": "ClientCIDR"
+						}
+					},
+					{
+						"IpProtocol": "icmp",
+						"FromPort": "-1",
+						"ToPort": "-1",
+						"CidrIp": {
+							"Ref": "ClientCIDR"
+						}
+					}
+				],
+				"Tags": [{
+					"Key": "Name",
+					"Value": "LB Incoming Traffic"
+				}]
+			}
+		},
+		"RemoteAccessSecurityGroup": {
+			"Type": "AWS::EC2::SecurityGroup",
+			"Properties": {
+				"GroupDescription": "Remote Access Group (SSH, Control Connection)",
+				"VpcId": {
+					"Ref": "VpcID"
+				},
+				"SecurityGroupIngress": [{
+						"IpProtocol": "tcp",
+						"FromPort": "22",
+						"ToPort": "22",
+						"SourceSecurityGroupId": {
+							"Ref": "ControllerSecurityGroup"
+						}
+					},
+					{
+						"IpProtocol": "tcp",
+						"FromPort": "5555",
+						"ToPort": "5555",
+						"SourceSecurityGroupId": {
+							"Ref": "ControllerSecurityGroup"
+						}
+					},
+					{
+						"IpProtocol": "tcp",
+						"FromPort": "5555",
+						"ToPort": "5555",
+						"SourceSecurityGroupId": {
+							"Ref": "UTMWorkerSecurityGroup"
+						}
+					},
+					{
+						"IpProtocol": "47",
+						"SourceSecurityGroupId": {
+							"Ref": "UTMWorkerSecurityGroup"
+						}
+					}
+				],
+				"Tags": [{
+					"Key": "Name",
+					"Value": "LB Access & Control"
+				}]
+			}
+		},
+		"LoadBalancer": {
+			"Type": "AWS::EC2::Instance",
+			"DependsOn": [
+				"IncomingTrafficLoadBalancerSecurityGroup",
+				"RemoteAccessSecurityGroup",
+				"InstanceIAM"
+			],
+			"Properties": {
+				"ImageId": {
+					"Fn::If": [
+						"UseRegionMap",
+						{
+							"Fn::FindInMap": [
+								"RegionMap",
+								{
+									"Ref": "AWS::Region"
+								},
+								"EGW"
+							]
+						},
+						{
+							"Ref": "ImageID"
+						}
+					]
+				},
+				"InstanceType": {
+					"Fn::If": [
+						"DetectInstanceSize",
+						{
+							"Fn::FindInMap": [
+								"RegionMap",
+								{
+									"Ref": "AWS::Region"
+								},
+								"EGWInstanceType"
+							]
+						},
+						{
+							"Ref": "InstanceSize"
+						}
+					]
+				},
+				"NetworkInterfaces": [{
+					"AssociatePublicIpAddress": "true",
+					"DeviceIndex": "0",
+					"GroupSet": [{
+							"Ref": "IncomingTrafficLoadBalancerSecurityGroup"
+						},
+						{
+							"Ref": "RemoteAccessSecurityGroup"
+						}
+					],
+					"SubnetId": {
+						"Ref": "LoadBalancerSubnetID"
+					}
+				}],
+				"SourceDestCheck": "false",
+				"IamInstanceProfile": {
+					"Ref": "InstanceIAM"
+				},
+				"KeyName": {
+					"Ref": "KeyID"
+				},
+				"BlockDeviceMappings": [{
+					"DeviceName": "/dev/xvda",
+					"Ebs": {
+						"VolumeSize": "25"
+					}
+				}],
+				"UserData": {
+					"Fn::Base64": {
+						"Fn::Join": [
+							"",
+							[
+								"#!/bin/bash\n",
+								"date +'UserData start %c' > /tmp/user_data.log\n",
+								"/opt/aws/bin/cfn-init -s ",
+								{
+									"Ref": "AWS::StackId"
+								},
+								" -r LoadBalancer ",
+								"    --region ",
+								{
+									"Ref": "AWS::Region"
+								},
+								" -c InitEGW >> /tmp/user_data.log 2>&1\n",
+								"initctl start egw >> /tmp/user_data.log 2>&1\n",
+								"/opt/aws/bin/cfn-signal '",
+								{
+									"Ref": "WaitHandle"
+								},
+								"' >> /tmp/user_data.log 2>&1\n",
+								"echo export AWS_DEFAULT_REGION=",
+								{
+									"Ref": "AWS::Region"
+								},
+								" > /etc/profile.d/aws-egw.sh\n",
+								"echo export AWS_INSTANCE_ID=`/opt/aws/bin/ec2-metadata --instance-id | cut -d ' ' -f 2` >> /etc/profile.d/aws-egw.sh 2>> /tmp/user_data.log\n",
+								"date +'UserData end %c' >> /tmp/user_data.log\n",
+								"exit 0\n"
+							]
+						]
+					}
+				},
+				"Tags": [{
+					"Key": "Name",
+					"Value": "LoadBalancer LB"
+				}]
+			},
+			"Metadata": {
+				"AWS::CloudFormation::Init": {
+					"configSets": {
+						"InitEGW": [
+							"InitEGW"
+						]
+					},
+					"InitEGW": {
+						"files": {
+							"/etc/egw.conf": {
+								"content": {
+									"Fn::Join": [
+										"",
+										[
+											"{\n",
+											"  \"prefix\": ",
+											{
+												"Ref": "LoadBalancerTunnelPrefix"
+											},
+											",\n",
+											"  \"uid\": ",
+											{
+												"Ref": "LoadBalancerUID"
+											},
+											",\n",
+											"  \"rest_auth_token\": \"",
+											{
+												"Ref": "AuthToken"
+											},
+											"\"\n",
+											"}\n"
+										]
+									]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"WaitHandle": {
+			"Type": "AWS::CloudFormation::WaitConditionHandle"
+		},
+		"WaitCondition": {
+			"Type": "AWS::CloudFormation::WaitCondition",
+			"DependsOn": [
+				"LoadBalancer"
+			],
+			"Properties": {
+				"Handle": {
+					"Ref": "WaitHandle"
+				},
+				"Count": "1",
+				"Timeout": "600"
+			}
+		},
+		"LoadBalancerAutoRecover": {
+			"Type": "AWS::CloudWatch::Alarm",
+			"DependsOn": [
+				"LoadBalancer"
+			],
+			"Properties": {
+				"AlarmDescription": "Recovering LoadBalancer when underlying hardware fails.",
+				"Namespace": "AWS/EC2",
+				"MetricName": "StatusCheckFailed_System",
+				"Statistic": "Minimum",
+				"Period": "60",
+				"EvaluationPeriods": "1",
+				"ComparisonOperator": "GreaterThanThreshold",
+				"Threshold": "0",
+				"AlarmActions": [{
+					"Fn::Join": [
+						"",
+						[
+							"arn:",
+							{
+								"Fn::FindInMap": [
+									"RegionMap",
+									{
+										"Ref": "AWS::Region"
+									},
+									"ARN"
+								]
+							},
+							":automate:",
+							{
+								"Ref": "AWS::Region"
+							},
+							":ec2:recover"
+						]
+					]
+				}],
+				"Dimensions": [{
+					"Name": "InstanceId",
+					"Value": {
+						"Ref": "LoadBalancer"
+					}
+				}]
+			}
+		},
+		"LoadBalancerRestart": {
+			"Type": "AWS::CloudWatch::Alarm",
+			"DependsOn": [
+				"LoadBalancer"
+			],
+			"Properties": {
+				"AlarmDescription": "Restarting LoadBalancer when it fails to respond.",
+				"Namespace": "AWS/EC2",
+				"MetricName": "StatusCheckFailed_Instance",
+				"Statistic": "Minimum",
+				"Period": "60",
+				"EvaluationPeriods": "1",
+				"ComparisonOperator": "GreaterThanThreshold",
+				"Threshold": "0",
+				"AlarmActions": [{
+					"Fn::Join": [
+						"",
+						[
+							"arn:",
+							{
+								"Fn::FindInMap": [
+									"RegionMap",
+									{
+										"Ref": "AWS::Region"
+									},
+									"ARN"
+								]
+							},
+							":swf:",
+							{
+								"Ref": "AWS::Region"
+							},
+							":",
+							{
+								"Ref": "AWS::AccountId"
+							},
+							":action/actions/AWS_EC2.InstanceId.Reboot/1.0"
+						]
+					]
+				}],
+				"Dimensions": [{
+					"Name": "InstanceId",
+					"Value": {
+						"Ref": "LoadBalancer"
+					}
+				}]
+			}
+		}
+	},
+	"Outputs": {
+		"LoadBalancerIP": {
+			"Value": {
+				"Fn::GetAtt": [
+					"LoadBalancer",
+					"PrivateIp"
+				]
+			},
+			"Description": "Private IP address of the Load Balancer"
+		}
+	}
 }

--- a/egw/1.0/egw.template
+++ b/egw/1.0/egw.template
@@ -23,13 +23,13 @@
 			"Type": "String",
 			"Default": "default"
 		},
-		"ControllerSecurityGroup": {
-			"Description": "Security group ID of the Controller node. Only SSH access to the Gateway will be allowed from this security group.",
-			"Type": "AWS::EC2::SecurityGroup::Id"
+		"ControllerSubnets": {
+			"Description": "Enter the subnets used by the UTM controller, separated by commas (e.g. 10.42.1.0/24,10.42.2.0/24). SSH access to the Gateway will only be allowed from these ranges.",
+			"Type": "CommaDelimitedList"
 		},
-		"UTMWorkerSecurityGroup": {
-			"Description": "Security group ID of the instances the Gateway should balance traffic to.",
-			"Type": "AWS::EC2::SecurityGroup::Id"
+		"UTMWorkerSubnets": {
+			"Description": "Enter the subnets used by the UTM workers, separated by commas (e.g. 10.42.10.0/24,10.42.11.0/24).",
+			"Type": "CommaDelimitedList"
 		},
 		"AuthToken": {
 			"Description": "AuthToken for API access. This token would be used as a shared secret for API communication between Gateway and the UTMs.",
@@ -43,7 +43,7 @@
 			"MaxValue": 16383
 		},
 		"LoadBalancerTunnelPrefix": {
-			"Description": "The network prefix (e.g 240.0.0.0/8) to use (changes only required in case of conflict).",
+			"Description": "The network prefix (e.g. 240.0.0.0/8) to use (changes only required in case of conflict).",
 			"Type": "Number",
 			"Default": 240,
 			"MinValue": 240,
@@ -58,7 +58,7 @@
 			"Type": "String"
 		},
 		"UTMCIDR": {
-			"Description": "CIDR of the VPC containing the UTM controller and workers.",
+			"Description": "CIDR of the VPC containing the UTM controller and workers (e.g. 10.42.0.0/16).",
 			"Type": "String",
 			"AllowedPattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/([0-9]|[1-2][0-9]|3[0-2]))$",
 			"ConstraintDescription": "Must be IPv4 CIDR notation: X.X.X.X/X"
@@ -93,8 +93,8 @@
 						"VpcID",
 						"InternetGateway",
 						"UTMGateway",
-						"ControllerSecurityGroup",
-						"UTMWorkerSecurityGroup",
+						"ControllerSubnets",
+						"UTMWorkerSubnets",
 						"ClientCIDR",
 						"UTMCIDR"
 					]
@@ -142,11 +142,11 @@
 				"UTMCIDR": {
 					"default": "CIDR of the UTM controller and worker VPC (required)"
 				},
-				"ControllerSecurityGroup": {
-					"default": "Security Group of the Controller node (required)"
+				"ControllerSubnets": {
+					"default": "Subnets of the Controller nodes (required)"
 				},
-				"UTMWorkerSecurityGroup": {
-					"default": "Security Group of the Worker nodes (required)"
+				"UTMWorkerSubnets": {
+					"default": "Subnets of the Worker nodes (required)"
 				},
 				"KeyID": {
 					"default": "SSH Key (required)"
@@ -449,30 +449,76 @@
 						"IpProtocol": "tcp",
 						"FromPort": "22",
 						"ToPort": "22",
-						"SourceSecurityGroupId": {
-							"Ref": "ControllerSecurityGroup"
+						"CidrIp": {
+							"Fn::Select": ["0", {
+								"Ref": "ControllerSubnets"
+							}]
+						}
+					},
+					{
+						"IpProtocol": "tcp",
+						"FromPort": "22",
+						"ToPort": "22",
+						"CidrIp": {
+							"Fn::Select": ["1", {
+								"Ref": "ControllerSubnets"
+							}]
 						}
 					},
 					{
 						"IpProtocol": "tcp",
 						"FromPort": "5555",
 						"ToPort": "5555",
-						"SourceSecurityGroupId": {
-							"Ref": "ControllerSecurityGroup"
+						"CidrIp": {
+							"Fn::Select": ["0", {
+								"Ref": "ControllerSubnets"
+							}]
 						}
 					},
 					{
 						"IpProtocol": "tcp",
 						"FromPort": "5555",
 						"ToPort": "5555",
-						"SourceSecurityGroupId": {
-							"Ref": "UTMWorkerSecurityGroup"
+						"CidrIp": {
+							"Fn::Select": ["1", {
+								"Ref": "ControllerSubnets"
+							}]
+						}
+					},
+					{
+						"IpProtocol": "tcp",
+						"FromPort": "5555",
+						"ToPort": "5555",
+						"CidrIp": {
+							"Fn::Select": ["0", {
+								"Ref": "UTMWorkerSubnets"
+							}]
+						}
+					},
+					{
+						"IpProtocol": "tcp",
+						"FromPort": "5555",
+						"ToPort": "5555",
+						"CidrIp": {
+							"Fn::Select": ["1", {
+								"Ref": "UTMWorkerSubnets"
+							}]
 						}
 					},
 					{
 						"IpProtocol": "47",
-						"SourceSecurityGroupId": {
-							"Ref": "UTMWorkerSecurityGroup"
+						"CidrIp": {
+							"Fn::Select": ["0", {
+								"Ref": "UTMWorkerSubnets"
+							}]
+						}
+					},
+					{
+						"IpProtocol": "47",
+						"CidrIp": {
+							"Fn::Select": ["1", {
+								"Ref": "UTMWorkerSubnets"
+							}]
 						}
 					}
 				],


### PR DESCRIPTION
Current template omits the creation of a route back to the UTM controller and workers in the new route table, and as such fails to stabilize OGW connectivity without manual reconfiguration of the route table.

Suggested modifications enable customers to specify peering ID or Transit Gateway ID and CIDR of the UTM VPC, and based on the type of connection a route with the correct gateway type will be created conditionally.